### PR TITLE
make mitglieder objects pickle-able

### DIFF
--- a/pynami/schemas/mgl.py
+++ b/pynami/schemas/mgl.py
@@ -257,6 +257,12 @@ class Mitglied:
             super().__setattr__(name, value)
         except AttributeError:
             self.data[name] = value
+            
+    def __getstate__(self):
+        return vars(self)
+
+    def __setstate__(self, state):
+        vars(self).update(state)
 
     def update(self, nami):
         """


### PR DESCRIPTION
Adding __getstate__() and __setstate__() methods to the mitglied class makes it possible to pickle the object. This can be useful to develop against this library because the objects can be cached on harddrive during test runs. This reduces unnecessary accesses to nami.